### PR TITLE
Added logic to skip ahead to next intact message after overflow

### DIFF
--- a/src/qs/qs.c
+++ b/src/qs/qs.c
@@ -472,6 +472,13 @@ void QS_endRec_(void) {
     if (QS_priv_.used > end) {
         QS_priv_.used = end;   // the whole buffer is used
         QS_priv_.tail = head;  // shift the tail to the old data
+        // Skip ahead to next intact message at the tail.
+        for (;;) {
+            uint16_t discarded_b = QS_getByte();
+            if (discarded_b == QS_EOD || discarded_b == QS_FRAME) {
+                break;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Added logic to skip ahead to next intact message after overflowing the QS queue, this removes spammy "Bad checksum" errors.

This was discovered while having an issue of not being able to send the QS messages fast enough, which leads to an overflow of the QS buffer (fixed capacity circular buffer), which overwrites the data at the TX end (tail). This results in pretty much all subsequent messages coming out being corrupted, leading to a massive amount of "Bad checksum error" spamming the qspy output without leaving anything useful.

This PR just adds simple logic so that when the buffer is overflown (clobbering the tail), the tail is seek'ed forward to the next intact message by consuming bytes up to and including the next QS_FRAME.

The resulting behavior is that the overflowing condition results in "Discontinuity" errors rather than a wall of checksum errors, which is much more intuitive to diagnose the issue. It incurs more additional loss of information since the partially clobbered message at the tail is not lost already by the time this code reached. And finally, the additional non-deterministic timing of that loop is innocuous in a debugging facility (behind Q_SPY flag).

I tested this in my project and it works as described above.
I'm not sure if there's a test suite somewhere where this regression test condition should be added to. That should be pretty trivial to do.